### PR TITLE
Bugfix: resume, requirements.txt

### DIFF
--- a/fairdarts/train_search.py
+++ b/fairdarts/train_search.py
@@ -123,7 +123,7 @@ def main():
       start_epoch = checkpoint['epoch']
       dur_time = checkpoint['dur_time']
       model_optimizer.load_state_dict(checkpoint['model_optimizer'])
-      architect.arch_optimizer.load_state_dict(checkpoint['arch_optimizer'])
+      architect.optimizer.load_state_dict(checkpoint['arch_optimizer'])
       model.restore(checkpoint['network_states'])
       logging.info('=> loaded checkpoint \'{}\'(epoch {})'.format(args.resume, start_epoch))
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ Pillow==6.2.0
 pyparsing==2.4.2
 python-dateutil==2.8.0
 six==1.12.0
-thop==0.0.31.post1910221501
+thop>=0.0.31,<0.0.32
 torch==1.1.0
 torchvision==0.2.1


### PR DESCRIPTION
1. error at resume: 
In [fairdarts/train_search.py](https://github.com/xiaomi-automl/FairDARTS/blob/874245ed63e54b858e4d1be1b3640e4bc870c83e/fairdarts/train_search.py#L126), it loads an optimizer checkpoint by
  `architect.**arch_optimizer**.load_state_dict(checkpoint['arch_optimizer'])`
But as in [fairdarts/architect.py](https://github.com/xiaomi-automl/FairDARTS/blob/874245ed63e54b858e4d1be1b3640e4bc870c83e/fairdarts/architect.py#L15),
there is no `arch_optimizer` in Architect class but `optimizer`.

2. requirements.txt
Pip has trouble with installing `thop==0.0.31.post1910221501`
There are some thop versions with 0.0.31.post~, but not exact 0.0.31.post1910221501.
